### PR TITLE
Remove any whitespaces/newlines and other non-hexadecimal digit

### DIFF
--- a/petall.py
+++ b/petall.py
@@ -9,16 +9,16 @@ private_key = ""
 aavegotchi_abi = ""
 aavegotchi_diamond = ""
 with open("matic_rpc.secret", "r") as reader:
-    rpc = reader.read()
+    rpc = reader.read().strip()
 
 with open("abi.json", "r") as reader:
-    aavegotchi_abi = reader.read()
+    aavegotchi_abi = reader.read().strip()
 
 with open("aavegotchiDiamond.txt", "r") as reader:
-    aavegotchi_diamond = reader.read()
+    aavegotchi_diamond = reader.read().strip()
 
 with open("private_key.secret", "r") as reader:
-    private_key = reader.read()
+    private_key = reader.read().strip()
 
 web3 = Web3(Web3.HTTPProvider(rpc))
 from web3.middleware import geth_poa_middleware


### PR DESCRIPTION
This is mostly for the private key, but figured it wouldn't hurt on the others too. 

I couldn't see what was wrong with my private key file but somehow there was a non-hexidecimal digit there - newline or ? Was quicker just to `strip()` it out then figure out what was going on.